### PR TITLE
Fix #117: Order places not showing error

### DIFF
--- a/management-webclient/src/components/orders/OrdersMainPage.vue
+++ b/management-webclient/src/components/orders/OrdersMainPage.vue
@@ -2,20 +2,40 @@
   <div class="general-padding" id="order-view">
     <h3>Orders</h3>
 
-    <b-tabs>
-      <template slot="tabs">
-        <b-nav-item :active="orderStatus == 'RECEIVED'" @click="tabClicked('RECEIVED')">Received</b-nav-item>
-        <b-nav-item :active="orderStatus == 'CONFIRMED'" @click="tabClicked('CONFIRMED')">Confirmed</b-nav-item>
-        <b-nav-item
-          :active="orderStatus == 'IN-PROGRESS'"
-          @click="tabClicked('IN-PROGRESS')"
-        >In Progress</b-nav-item>
-        <b-nav-item :active="orderStatus == 'COMPLETED'" @click="tabClicked('COMPLETED')">Completed</b-nav-item>
-        <b-nav-item :active="orderStatus == 'CANCELLED'" @click="tabClicked('CANCELLED')">Cancelled</b-nav-item>
-      </template>
+    <b-tabs pills class="mt-4">
+      <b-tab disabled title="Filter by:" title-link-class="pl-0"/>
+      <b-tab
+        v-for="(tab,tind) in orderStatusTabs"
+        :key="tind"
+        :title="tab.title"
+        :active="orderStatus == tab.value"
+        @click="tabClicked(tab.value)"
+      />
     </b-tabs>
+    <hr/>
 
     <div class="order-list">
+      <b-row>
+        <b-col md="6">Per page &nbsp;&nbsp;&nbsp;
+          <b-form-select
+            v-model="pagination.limit"
+            :options="perPageOptions"
+            style="max-width: 100px"
+            size="sm"
+            @change="pageLimitChanged"
+          />
+        </b-col>
+        <b-col md="6">
+          <b-pagination
+            :total-rows="pagination.total"
+            v-model="pagination.page"
+            :per-page="pagination.limit"
+            @change="pageChanged"
+            aria-controls="content_loop"
+            align="right"
+          />
+        </b-col>
+      </b-row>
       <order-list/>
     </div>
   </div>
@@ -31,7 +51,31 @@ export default {
     OrderList,
   },
   data() {
-    return {};
+    return {
+      perPageOptions: [10, 20, 30, 50, 100],
+      orderStatusTabs: [
+        {
+          title: 'Received',
+          value: 'RECEIVED'
+        },
+        {
+          title: 'Confirmed',
+          value: 'CONFIRMED'
+        },
+        {
+          title: 'In Progress',
+          value: 'IN-PROGRESS'
+        },
+        {
+          title: 'Completed',
+          value: 'COMPLETED'
+        },
+        {
+          title: 'Cancelled',
+          value: 'CANCELLED'
+        },
+      ]
+    };
   },
 
   async created() {
@@ -56,11 +100,22 @@ export default {
     tabClicked(tab) {
       this.$store.dispatch('orderStore/getOrdersByStatus', tab);
     },
+
+    async pageLimitChanged(limit) {
+      this.pagination.limit = limit;
+      this.pageChanged(1);
+    },
+
+    async pageChanged(pageNum) {
+      this.pagination.page = pageNum;
+      await this.$store.dispatch('orderStore/getOrdersByStatus', this.orderStatus);
+    },
   },
 
   computed: {
     ...mapGetters({
       orderStatus: 'orderStore/orderStatus',
+      pagination: 'orderStore/pagination'
     }),
   },
 };

--- a/management-webclient/src/dto/PageDTO.json
+++ b/management-webclient/src/dto/PageDTO.json
@@ -1,6 +1,0 @@
-{
-  "pagingOptions": {
-		"page": 1,
-		"limit": 10
-	}
-}

--- a/management-webclient/src/store/orders.js
+++ b/management-webclient/src/store/orders.js
@@ -1,6 +1,6 @@
 import Vue from 'vue';
 import ProxyUrl from '@/constants/ProxyUrls';
-import PageSetup from '@/dto/PageDTO.json';
+import Pagination from '@/dto/Pagination.json';
 import _ from 'lodash';
 
 export default {
@@ -9,7 +9,7 @@ export default {
     orders: [],
     orderStatus: '',
 
-    pagination: {},
+    pagination: _.cloneDeep(Pagination),
     openOrder: null,
   },
 
@@ -200,12 +200,13 @@ export default {
 
     async getOrdersByStatus({
       commit,
+      state
     }, status) {
-      let reqObj = {
+      const reqObj = {
         orderStatus: status,
+        pagingOptions: state.pagination,
+        sortRule: '-auditLog.createdOn'
       };
-
-      reqObj = _.assignIn(reqObj, PageSetup);
 
       try {
         const {
@@ -261,5 +262,9 @@ export default {
     openOrder(state) {
       return state.openOrder;
     },
+
+    pagination(state) {
+      return state.pagination;
+    }
   },
 };


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What is this doing?**
Order places wasn't being shown in admin cause there was no pagination
- Added Pagination
- Tabs were somehow disappearing too. So, changed the logic there as well

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [x] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe how it impacts the application:


**The PR fulfills these requirements:**

- [x] It's submitted to the `develop` branch, _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `Fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] New/updated tests are included

**Other information:**
